### PR TITLE
Relax the sdl2 features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ description = "A render-backend independant egui backend for sdl2"
 members = ["examples/*"]
 
 [dependencies]
-sdl2 = { version = "0.35", features = ["raw-window-handle", "static-link", "bundled"] }
+sdl2 = { version = "0.35", features = ["raw-window-handle"] }
 egui = "0.18"
 anyhow = "1.0"


### PR DESCRIPTION
I am working on a project using this library and I found that it was not
building. After investigation I found that the cause is that a feature was
being enabled by egui_sdl2_platform that was causing the build failure.

When this crate sets these features, it makes anything depending on it not
build on Linux using system libraries.
