### PR TITLE
Fix: allow SDL2 to run in KMS/DRM mode without `from_system`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_sdl2_platform"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 description = "A render-backend independant egui backend for sdl2"
@@ -13,6 +13,7 @@ members = ["examples/*"]
 sdl2 = { git = "https://github.com/Rust-SDL2/rust-sdl2", revion = "31e830e", features = ["raw-window-handle"] }
 egui = "0.21"
 anyhow = "1.0"
+log = "*"
 
 [features]
 sdl2_unsafe_textures = ["sdl2/unsafe_textures"]

--- a/examples/sdl2_plus_glow/src/main.rs
+++ b/examples/sdl2_plus_glow/src/main.rs
@@ -111,7 +111,7 @@ async fn run() -> anyhow::Result<()> {
             // Let the egui platform handle the event
             platform.handle_event(&event, &sdl, &video);
         }
-        
+
         if let Some(_fps) = timestep.frame_rate() {
             println!("{:?}", _fps);
         }


### PR DESCRIPTION
SDL2 is capable of running in KMS/DRM mode without any display manager or compositor. When it is run like this it is not able to get a system cursor so instead of erroring on it we log a warning and carry on.